### PR TITLE
Improve milestone text in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,6 +16,7 @@
     [ 'name' => 'purse',  'cost' => 15, 'emoji' => '👜' ],
     [ 'name' => 'mejuri', 'cost' => 15, 'emoji' => '💍' ],
     [ 'name' => 'omakase restaurant', 'cost' => 20, 'emoji' => '🍣' ],
+    [ 'name' => 'Save streak', 'cost' => 3, 'emoji' => '🛟' ],
   ];
 
   // Ensure non-negative, since points start at 0

--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@
   $repeatingMilestones = [
     [ 'label' => 'kiss', 'repeats_every' => 4,  'kind' => 'icon', 'icon' => '💋' ],
     [ 'label' => 'Store of your choice', 'repeats_every' => 10, 'kind' => 'pill' ],
-    [ 'label' => 'Experience (e.g. nail salon)', 'repeats_every' => 17, 'kind' => 'pill' ],
+    [ 'label' => 'Experience (e.g. nail salon, spa day)', 'repeats_every' => 17, 'kind' => 'pill' ],
   ];
 
   // Custom, one-off milestones mapping (won't repeat)

--- a/index.php
+++ b/index.php
@@ -6,6 +6,10 @@
   // Email-friendly mode: disables animations and adds legacy attrs like bgcolor
   $email_mode = false;
 
+  // Current streak (hardcoded): number of days without any beauty point loss
+  // This is display-only; no logic is implemented here.
+  $streakDays = 3; // example
+
   // Second metric: kisses (hardcoded, manually incremented when hitting kiss milestones)
   $kisses = 1; // example
   $kissPrizes = [
@@ -63,6 +67,17 @@
         <td align="center" style="padding:20px 12px;">
           <!-- Card container -->
           <table role="presentation" width="360" cellpadding="0" cellspacing="0" border="0" style="width:360px;max-width:94%;background:#ffffff;border-radius:16px;border:2px solid #ffc5dd;" bgcolor="#ffffff">
+            <tr>
+              <td align="center" style="padding:14px 20px 0 20px;">
+                <span style="display:inline-block;background:#ffe3f0;border:1px solid #ffb6d0;color:#ff2b83;border-radius:999px;padding:6px 12px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;<?php if (!$email_mode) { echo 'animation:popIn 500ms ease-out both;'; } ?>">
+                  <span role="img" aria-label="fire" title="fire" style="margin-right:6px;">🔥</span>
+                  Current streak: <strong style="color:#ff2b83;"><?php echo (int)$streakDays; ?></strong> day<?php echo ((int)$streakDays === 1 ? '' : 's'); ?>
+                </span>
+                <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:16px;color:#b34a7f;margin-top:6px;">
+                  Maintain your streak (no beauty point loss) and you’ll earn <?php echo (int)$streakDays; ?> kisses at the end of today.
+                </div>
+              </td>
+            </tr>
             <tr>
               <td align="center" style="padding:20px 20px 8px 20px;">
                 <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:22px;line-height:28px;color:#ff2b83;font-weight:bold;<?php if (!$email_mode) { echo 'animation:popIn 600ms ease-out both;'; } ?>">

--- a/index.php
+++ b/index.php
@@ -29,7 +29,7 @@
   $repeatingMilestones = [
     [ 'label' => 'kiss', 'repeats_every' => 4,  'kind' => 'icon', 'icon' => '💋' ],
     [ 'label' => 'Store of your choice', 'repeats_every' => 10, 'kind' => 'pill' ],
-    [ 'label' => 'Experience (e.g. nail salon, spa day)', 'repeats_every' => 17, 'kind' => 'pill' ],
+    [ 'label' => 'Experience (e.g. nail salon, spa day, hair day)', 'repeats_every' => 17, 'kind' => 'pill' ],
   ];
 
   // Custom, one-off milestones mapping (won't repeat)

--- a/index.php
+++ b/index.php
@@ -11,6 +11,7 @@
   $kissPrizes = [
     [ 'name' => 'purse',  'cost' => 15, 'emoji' => '👜' ],
     [ 'name' => 'mejuri', 'cost' => 15, 'emoji' => '💍' ],
+    [ 'name' => 'omakase restaurant', 'cost' => 20, 'emoji' => '🍣' ],
   ];
 
   // Ensure non-negative, since points start at 0

--- a/index.php
+++ b/index.php
@@ -27,8 +27,8 @@
   // kind: 'icon' renders in the dot column as an emoji; 'pill' stacks as a label
   $repeatingMilestones = [
     [ 'label' => 'kiss', 'repeats_every' => 4,  'kind' => 'icon', 'icon' => '💋' ],
-    [ 'label' => 'store', 'repeats_every' => 10, 'kind' => 'pill' ],
-    [ 'label' => 'experience', 'repeats_every' => 17, 'kind' => 'pill' ],
+    [ 'label' => 'Store of your choice', 'repeats_every' => 10, 'kind' => 'pill' ],
+    [ 'label' => 'Experience (e.g. nail salon)', 'repeats_every' => 17, 'kind' => 'pill' ],
   ];
 
   // Custom, one-off milestones mapping (won't repeat)

--- a/index.php
+++ b/index.php
@@ -69,13 +69,23 @@
           <table role="presentation" width="360" cellpadding="0" cellspacing="0" border="0" style="width:360px;max-width:94%;background:#ffffff;border-radius:16px;border:2px solid #ffc5dd;" bgcolor="#ffffff">
             <tr>
               <td align="center" style="padding:14px 20px 0 20px;">
-                <span style="display:inline-block;background:#ffe3f0;border:1px solid #ffb6d0;color:#ff2b83;border-radius:999px;padding:6px 12px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;<?php if (!$email_mode) { echo 'animation:popIn 500ms ease-out both;'; } ?>">
-                  <span role="img" aria-label="fire" title="fire" style="margin-right:6px;">🔥</span>
-                  Current streak: <strong style="color:#ff2b83;"><?php echo (int)$streakDays; ?></strong> day<?php echo ((int)$streakDays === 1 ? '' : 's'); ?>
-                </span>
-                <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:16px;color:#b34a7f;margin-top:6px;">
-                  Maintain your streak (no beauty point loss) and you’ll earn <?php echo (int)$streakDays; ?> kisses at the end of today.
-                </div>
+                <?php if ((int)$streakDays > 0): ?>
+                  <span style="display:inline-block;background:#ffe3f0;border:1px solid #ffb6d0;color:#ff2b83;border-radius:999px;padding:6px 12px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;<?php if (!$email_mode) { echo 'animation:popIn 500ms ease-out both;'; } ?>">
+                    <span role="img" aria-label="fire" title="fire" style="margin-right:6px;">🔥</span>
+                    Current streak: <strong style="color:#ff2b83;">&<?php echo (int)$streakDays; ?></strong> day<?php echo ((int)$streakDays === 1 ? '' : 's'); ?>
+                  </span>
+                  <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:16px;color:#b34a7f;margin-top:6px;">
+                    Maintain your streak (no beauty point loss) and you’ll earn <?php echo (int)$streakDays; ?> kisses at the end of today.
+                  </div>
+                <?php else: ?>
+                  <span style="display:inline-block;background:#ffe3f0;border:1px solid #ffb6d0;color:#ff2b83;border-radius:999px;padding:6px 12px;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;<?php if (!$email_mode) { echo 'animation:popIn 500ms ease-out both;'; } ?>">
+                    <span role="img" aria-label="fire" title="fire" style="margin-right:6px;">🔥</span>
+                    No current streak
+                  </span>
+                  <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:16px;color:#b34a7f;margin-top:6px;">
+                    When you have a streak (no beauty point loss), you’ll earn that many kisses at the end of each day. For example, a 3-day streak earns 3 kisses at day’s end.
+                  </div>
+                <?php endif; ?>
               </td>
             </tr>
             <tr>

--- a/index.php
+++ b/index.php
@@ -13,10 +13,10 @@
   // Second metric: kisses (hardcoded, manually incremented when hitting kiss milestones)
   $kisses = 1; // example
   $kissPrizes = [
-    [ 'name' => 'purse',  'cost' => 15, 'emoji' => '👜' ],
-    [ 'name' => 'mejuri', 'cost' => 15, 'emoji' => '💍' ],
-    [ 'name' => 'omakase restaurant', 'cost' => 20, 'emoji' => '🍣' ],
-    [ 'name' => 'Save streak', 'cost' => 3, 'emoji' => '🛟' ],
+    [ 'name' => 'purse',  'cost' => 150, 'emoji' => '👜' ],
+    [ 'name' => 'mejuri', 'cost' => 150, 'emoji' => '💍' ],
+    [ 'name' => 'omakase restaurant', 'cost' => 200, 'emoji' => '🍣' ],
+    [ 'name' => 'Save streak', 'cost' => 30, 'emoji' => '🛟' ],
   ];
 
   // Ensure non-negative, since points start at 0
@@ -32,6 +32,7 @@
   // Generic repeating milestones: define label and repeats_every
   // kind: 'icon' renders in the dot column as an emoji; 'pill' stacks as a label
   $repeatingMilestones = [
+    [ 'label' => '+10 kisses', 'repeats_every' => 4,  'kind' => 'pill' ],
     [ 'label' => 'kiss', 'repeats_every' => 4,  'kind' => 'icon', 'icon' => '💋' ],
     [ 'label' => 'Store (e.g. Clothes, sephora)', 'repeats_every' => 10, 'kind' => 'pill' ],
     [ 'label' => 'Experience (e.g. nail salon, spa day, hair day)', 'repeats_every' => 17, 'kind' => 'pill' ],

--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@
   // kind: 'icon' renders in the dot column as an emoji; 'pill' stacks as a label
   $repeatingMilestones = [
     [ 'label' => 'kiss', 'repeats_every' => 4,  'kind' => 'icon', 'icon' => '💋' ],
-    [ 'label' => 'Store of your choice', 'repeats_every' => 10, 'kind' => 'pill' ],
+    [ 'label' => 'Store (e.g. Clothes, sephora)', 'repeats_every' => 10, 'kind' => 'pill' ],
     [ 'label' => 'Experience (e.g. nail salon, spa day, hair day)', 'repeats_every' => 17, 'kind' => 'pill' ],
   ];
 

--- a/index.php
+++ b/index.php
@@ -36,7 +36,7 @@
   // Example: 13 => ['netflix subscription'].
   // You can add multiple per point: 21 => ['cute scrunchies', 'pink water bottle']
   $customMilestones = [
-    13 => ['netflix subscription'],
+    11 => ['Kitchen spoon rest'],
   ];
 ?>
 <!doctype html>


### PR DESCRIPTION
Update repeating milestone labels in `index.php` to more descriptive text as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-8492a44f-8040-476a-be8d-67b1ca1b61ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8492a44f-8040-476a-be8d-67b1ca1b61ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

