### PR TITLE
Update kitchen spoonrest and kiss item display

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@
   // Example: 13 => ['netflix subscription'].
   // You can add multiple per point: 21 => ['cute scrunchies', 'pink water bottle']
   $customMilestones = [
-    11 => ['Kitchen spoon rest'],
+    13 => ['Kitchen spoon rest'],
   ];
 ?>
 <!doctype html>
@@ -223,6 +223,9 @@
                                 </tr>
                                 <tr>
                                   <td align="center" style="padding:0 8px 8px 8px;">
+                                    <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;color:#b34a7f;white-space:nowrap;margin-bottom:2px;">
+                                      <?php echo $alt; ?>
+                                    </div>
                                     <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;color:#ff2b83;white-space:nowrap;">
                                       <?php echo (int)$prize['cost']; ?> kisses
                                     </div>
@@ -250,7 +253,10 @@
                             <?php else: ?>
                               <span role="img" aria-label="<?php echo $alt; ?>" title="<?php echo $alt; ?>" style="display:block;width:56px;height:56px;line-height:56px;font-size:28px;text-align:center;border-radius:8px;background:#ffffff;">🎁</span>
                             <?php endif; ?>
-                            <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;color:#ff2b83;margin-top:6px;text-align:center;white-space:nowrap;">
+                            <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;color:#b34a7f;margin-top:6px;text-align:center;white-space:nowrap;">
+                              <?php echo $alt; ?>
+                            </div>
+                            <div style="font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:12px;line-height:14px;color:#ff2b83;margin-top:2px;text-align:center;white-space:nowrap;">
                               <?php echo (int)$prize['cost']; ?> kisses
                             </div>
                           </span>


### PR DESCRIPTION
Update kitchen spoon rest milestone to 13 points and display kiss item names in the shop UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-874a64ef-9dfa-4a1e-a511-8c153b1a4d55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-874a64ef-9dfa-4a1e-a511-8c153b1a4d55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

