### PR TITLE
Adjust progress and compliment bar widths

### DIFF
--- a/index.php
+++ b/index.php
@@ -166,11 +166,11 @@
 
       /* 3) Harden ticker visuals & containment */
       #cardWrap { max-width:100%; }
-      .ticker { width:100%; max-width:100%; overflow:hidden; -webkit-mask-image: linear-gradient(to right, transparent 0, black 14px, black calc(100% - 14px), transparent 100%); mask-image: linear-gradient(to right, transparent 0, black 14px, black calc(100% - 14px), transparent 100%); }
+      .ticker { width:100%; max-width:200px; overflow:hidden; -webkit-mask-image: linear-gradient(to right, transparent 0, black 14px, black calc(100% - 14px), transparent 100%); mask-image: linear-gradient(to right, transparent 0, black 14px, black calc(100% - 14px), transparent 100%); }
       .tickerTrack { contain: layout paint; will-change: transform; }
 
       /* 4) Progress bar safety */
-      .miniBar { width:100%; max-width:100%; }
+      .miniBar { width:100%; max-width:200px; }
 
       /* 5) Mobile tuning for ticker */
       @media (max-width: 480px) {


### PR DESCRIPTION
Limit the width of the progress bar (`.miniBar`) and compliment bar (`.ticker`) to 200px to prevent the website from being too wide.

---
<a href="https://cursor.com/background-agent?bcId=bc-5acac7c4-5ced-4679-9dcf-0dbb0afcebd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5acac7c4-5ced-4679-9dcf-0dbb0afcebd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

